### PR TITLE
[OPS-384] feat: add personal api endpoints

### DIFF
--- a/app/api/v1/ai_credentials.py
+++ b/app/api/v1/ai_credentials.py
@@ -1,0 +1,312 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.api.v1.auth import get_current_user
+from app.core.database import get_db
+from app.models.ai_credential import AICredential
+from app.models.user import User
+from app.schemas.ai_credential import (
+    ActivateAICredentialResponse,
+    AICredentialResponse,
+    ListAICredentialsResponse,
+    ProviderModelsListResponse,
+    ProviderModelsResponse,
+    SaveAICredentialRequest,
+    SaveAICredentialResponse,
+    UpdateCurrentModelRequest,
+    UpdateCurrentModelResponse,
+)
+from app.utils.encryption import decrypt_api_key, encrypt_api_key, mask_api_key
+
+router = APIRouter()
+
+
+FIXED_PROVIDER_MODELS = {
+    "openai": [
+        "gpt-4.1",
+        "gpt-4.1-mini",
+        "gpt-4o",
+        "gpt-4o-mini",
+    ],
+    "openrouter": [
+        "openai/gpt-4o-mini",
+        "anthropic/claude-3.5-haiku",
+        "meta-llama/llama-3.1-8b-instruct",
+        "nvidia/nemotron-3-nano-30b-a3b:free",
+    ],
+    "google": [
+        "gemini-1.5-flash",
+        "gemini-1.5-pro",
+        "gemini-2.0-flash",
+    ],
+    "anthropic": [
+        "claude-haiku-4-0",
+        "claude-sonnet-4-0",
+        "claude-opus-4-0",
+    ],
+}
+
+
+def _build_ai_credential_response(
+    credential: AICredential, masked_api_key: str
+) -> dict:
+    return {
+        "id": credential.id,
+        "provider": credential.provider,
+        "status": credential.status,
+        "current_model": credential.current_model,
+        "models_json": credential.models_json or [],
+        "masked_api_key": masked_api_key,
+        "updated_at": credential.updated_at,
+    }
+
+
+@router.get("/models", response_model=ProviderModelsListResponse)
+def get_all_provider_models():
+    items = []
+    for provider, models in FIXED_PROVIDER_MODELS.items():
+        items.append(
+            {
+                "provider": provider,
+                "models": models,
+                "default_model": models[0] if models else None,
+            }
+        )
+    return {"items": items}
+
+
+@router.get("/models/{provider}", response_model=ProviderModelsResponse)
+def get_provider_models(provider: str):
+    normalized_provider = provider.strip().lower()
+    models = FIXED_PROVIDER_MODELS.get(normalized_provider)
+    if not models:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Provider not found in fixed model catalog",
+        )
+
+    return {
+        "provider": normalized_provider,
+        "models": models,
+        "default_model": models[0] if models else None,
+    }
+
+
+@router.post("/api-key", response_model=SaveAICredentialResponse)
+def save_api_key(
+    request: SaveAICredentialRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    fixed_models = FIXED_PROVIDER_MODELS.get(request.provider)
+    if not fixed_models:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Unsupported provider for fixed model catalog",
+        )
+
+    # Enforce single active key per user by deactivating older active rows.
+    db.query(AICredential).filter(
+        AICredential.user_id == current_user.id,
+        AICredential.status == "active",
+    ).update({"status": "inactive"}, synchronize_session=False)
+
+    try:
+        encrypted_api_key, iv, auth_tag = encrypt_api_key(request.api_key)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)
+        ) from exc
+
+    credential = AICredential(
+        user_id=current_user.id,
+        provider=request.provider,
+        encrypted_api_key=encrypted_api_key,
+        iv=iv,
+        auth_tag=auth_tag,
+        models_json=fixed_models,
+        current_model=fixed_models[0],
+        status="active",
+    )
+
+    db.add(credential)
+    db.commit()
+    db.refresh(credential)
+
+    try:
+        masked = mask_api_key(
+            decrypt_api_key(
+                credential.encrypted_api_key, credential.iv, credential.auth_tag
+            )
+        )
+    except ValueError:
+        masked = ""
+
+    return {
+        "message": "API key saved successfully",
+        "data": _build_ai_credential_response(credential, masked),
+    }
+
+
+@router.get("/api-keys", response_model=ListAICredentialsResponse)
+def list_api_keys(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    credentials = (
+        db.query(AICredential)
+        .filter(AICredential.user_id == current_user.id)
+        .order_by(AICredential.updated_at.desc())
+        .all()
+    )
+
+    items = []
+    for credential in credentials:
+        try:
+            plain_api_key = decrypt_api_key(
+                credential.encrypted_api_key,
+                credential.iv,
+                credential.auth_tag,
+            )
+            masked = mask_api_key(plain_api_key)
+        except ValueError:
+            masked = ""
+
+        items.append(_build_ai_credential_response(credential, masked))
+
+    return {"items": items}
+
+
+@router.patch(
+    "/api-key/{credential_id}/activate", response_model=ActivateAICredentialResponse
+)
+def activate_api_credential(
+    credential_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    credential = (
+        db.query(AICredential)
+        .filter(
+            AICredential.id == credential_id,
+            AICredential.user_id == current_user.id,
+        )
+        .first()
+    )
+
+    if not credential:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="AI credential not found",
+        )
+
+    db.query(AICredential).filter(
+        AICredential.user_id == current_user.id,
+        AICredential.status == "active",
+    ).update({"status": "inactive"}, synchronize_session=False)
+
+    credential.status = "active"
+    db.commit()
+    db.refresh(credential)
+
+    try:
+        plain_api_key = decrypt_api_key(
+            credential.encrypted_api_key,
+            credential.iv,
+            credential.auth_tag,
+        )
+        masked = mask_api_key(plain_api_key)
+    except ValueError:
+        masked = ""
+
+    return {
+        "message": "AI credential activated successfully",
+        "data": _build_ai_credential_response(credential, masked),
+    }
+
+
+@router.patch("/api-key/current-model", response_model=UpdateCurrentModelResponse)
+def update_current_model(
+    request: UpdateCurrentModelRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    credential = (
+        db.query(AICredential)
+        .filter(
+            AICredential.user_id == current_user.id,
+            AICredential.status == "active",
+        )
+        .order_by(AICredential.updated_at.desc())
+        .first()
+    )
+
+    if not credential:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active API credential found",
+        )
+
+    allowed_models = credential.models_json or []
+    if request.current_model not in allowed_models:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="current_model is not allowed for the active credential",
+        )
+
+    credential.current_model = request.current_model
+    db.commit()
+    db.refresh(credential)
+
+    try:
+        plain_api_key = decrypt_api_key(
+            credential.encrypted_api_key,
+            credential.iv,
+            credential.auth_tag,
+        )
+        masked = mask_api_key(plain_api_key)
+    except ValueError:
+        masked = ""
+
+    return {
+        "message": "Current model updated successfully",
+        "data": _build_ai_credential_response(credential, masked),
+    }
+
+
+@router.get("/api-key", response_model=AICredentialResponse)
+def get_api_key(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    credential = (
+        db.query(AICredential)
+        .filter(
+            AICredential.user_id == current_user.id,
+            AICredential.status == "active",
+        )
+        .order_by(AICredential.updated_at.desc())
+        .first()
+    )
+
+    if not credential:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active API key found",
+        )
+
+    try:
+        plain_api_key = decrypt_api_key(
+            credential.encrypted_api_key,
+            credential.iv,
+            credential.auth_tag,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to decrypt API key",
+        ) from exc
+
+    return {
+        **_build_ai_credential_response(credential, mask_api_key(plain_api_key)),
+    }

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,7 +5,8 @@ from typing import Optional, List
 
 class Settings(BaseSettings):
     model_config = ConfigDict(
-        env_file=".env", extra="ignore"  # Ignore extra fields in .env
+        env_file=".env",
+        extra="ignore",  # Ignore extra fields in .env
     )
 
     database_url: str
@@ -21,6 +22,7 @@ class Settings(BaseSettings):
     auto_verify_email: bool = True  # Auto-verify emails (skip email sending)
 
     secret_key: str
+    app_aes_key: str
     algorithm: str = "HS256"
     access_token_expire_minutes: int = 30
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI, HTTPException
 from app.api.v1 import (
     auth,
+    ai_credentials,
     oauth,
     user,
     wireframe,
@@ -16,7 +17,7 @@ from app.api.v1 import (
     analysis,
 )
 
-from app.api.v1.ws import planning_ws,design_ws,analysis_ws
+from app.api.v1.ws import planning_ws, design_ws, analysis_ws
 from app.core.database import engine, Base
 import logging
 import time
@@ -38,6 +39,9 @@ app = FastAPI(
 
 # Include routers
 app.include_router(auth.router, prefix="/api/v1/auth", tags=["authentication"])
+app.include_router(
+    ai_credentials.router, prefix="/api/v1/ai-credentials", tags=["ai_credentials"]
+)
 app.include_router(user.router, prefix="/api/v1/user", tags=["user"])
 app.include_router(srs.router, prefix="/api/v1/srs", tags=["srs_generator"])
 app.include_router(
@@ -49,15 +53,17 @@ app.include_router(files.router, prefix="/api/v1/files", tags=["file"])
 app.include_router(session.router, prefix="/api/v1/sessions", tags=["chat history"])
 app.include_router(folder.router, prefix="/api/v1/folders", tags=["folders"])
 
-app.include_router(design.router,prefix="/api/v1/design",tags=["design step"])
-app.include_router(planning.router,prefix="/api/v1/planning",tags=["planning step"])
-app.include_router(analysis.router,prefix="/api/v1/analysis",tags=["analysis"])
+app.include_router(design.router, prefix="/api/v1/design", tags=["design step"])
+app.include_router(planning.router, prefix="/api/v1/planning", tags=["planning step"])
+app.include_router(analysis.router, prefix="/api/v1/analysis", tags=["analysis"])
 
-app.include_router(planning_ws.router,prefix="/api/v1",tags=["planning step websocket"])
 app.include_router(
-    design_ws.router, prefix="/api/v1", tags=["design step websocket"]
+    planning_ws.router, prefix="/api/v1", tags=["planning step websocket"]
 )
-app.include_router(analysis_ws.router, prefix="/api/v1", tags=["analysis step websocket"])
+app.include_router(design_ws.router, prefix="/api/v1", tags=["design step websocket"])
+app.include_router(
+    analysis_ws.router, prefix="/api/v1", tags=["analysis step websocket"]
+)
 
 # Oauth routes
 app.include_router(oauth.router, prefix="/api/v1/oauth", tags=["oauth"])
@@ -97,9 +103,8 @@ async def startup_event():
                 raise e
             time.sleep(2)
 
-app.include_router(
-    one_click.router, prefix="/api/v1", tags=["one click flow"]
-)
+
+app.include_router(one_click.router, prefix="/api/v1", tags=["one click flow"])
 
 
 @app.get("/")

--- a/app/models/ai_credential.py
+++ b/app/models/ai_credential.py
@@ -1,0 +1,38 @@
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    ForeignKey,
+    Text,
+    JSON,
+    Index,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class AICredential(Base):
+    __tablename__ = "ai_credentials"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    provider = Column(String(50), nullable=False)
+    encrypted_api_key = Column(Text, nullable=False)
+    iv = Column(String(255), nullable=False)
+    auth_tag = Column(String(255), nullable=False)
+    models_json = Column(
+        JSONB().with_variant(JSON(), "sqlite"), nullable=False, default=list
+    )
+    current_model = Column(String(100), nullable=True)
+    status = Column(String(20), nullable=False, default="active")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    user = relationship("User", back_populates="ai_credentials")

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -25,3 +25,6 @@ class User(Base):
     identities = relationship(
         "UserIdentity", back_populates="user", cascade="all, delete-orphan"
     )
+    ai_credentials = relationship(
+        "AICredential", back_populates="user", cascade="all, delete-orphan"
+    )

--- a/app/schemas/ai_credential.py
+++ b/app/schemas/ai_credential.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from typing import List, Optional
+
+from pydantic import Field
+from pydantic import field_validator
+
+from app.schemas.base_response import BaseResponseModel
+
+
+class SaveAICredentialRequest(BaseResponseModel):
+    provider: str
+    api_key: str
+
+    @field_validator("provider")
+    @classmethod
+    def provider_not_empty(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if not normalized:
+            raise ValueError("provider is required")
+        return normalized
+
+    @field_validator("api_key")
+    @classmethod
+    def api_key_not_empty(cls, value: str) -> str:
+        if not value or not value.strip():
+            raise ValueError("api_key is required")
+        return value.strip()
+
+
+class UpdateCurrentModelRequest(BaseResponseModel):
+    current_model: str
+
+    @field_validator("current_model")
+    @classmethod
+    def current_model_not_blank(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("current_model is required")
+        return trimmed
+
+
+class AICredentialResponse(BaseResponseModel):
+    id: int
+    provider: str
+    status: str
+    current_model: Optional[str] = None
+    models_json: List[str] = Field(default_factory=list)
+    masked_api_key: str
+    updated_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class SaveAICredentialResponse(BaseResponseModel):
+    message: str
+    data: AICredentialResponse
+
+
+class UpdateCurrentModelResponse(BaseResponseModel):
+    message: str
+    data: AICredentialResponse
+
+
+class ListAICredentialsResponse(BaseResponseModel):
+    items: List[AICredentialResponse] = Field(default_factory=list)
+
+
+class ActivateAICredentialResponse(BaseResponseModel):
+    message: str
+    data: AICredentialResponse
+
+
+class ProviderModelsResponse(BaseResponseModel):
+    provider: str
+    models: List[str] = Field(default_factory=list)
+    default_model: Optional[str] = None
+
+
+class ProviderModelsListResponse(BaseResponseModel):
+    items: List[ProviderModelsResponse] = Field(default_factory=list)

--- a/app/services/ai_credentials.py
+++ b/app/services/ai_credentials.py
@@ -1,0 +1,48 @@
+from typing import Optional
+
+from sqlalchemy.orm import Session
+
+from app.models.ai_credential import AICredential
+from app.utils.encryption import decrypt_api_key
+
+
+def get_active_ai_credential_for_user(
+    db: Session,
+    user_id: int,
+) -> Optional[AICredential]:
+    return (
+        db.query(AICredential)
+        .filter(
+            AICredential.user_id == user_id,
+            AICredential.status == "active",
+        )
+        .order_by(AICredential.updated_at.desc())
+        .first()
+    )
+
+
+def resolve_ai_headers_for_user(
+    db: Session,
+    user_id: int,
+    model: Optional[str] = None,
+) -> dict[str, str]:
+    credential = get_active_ai_credential_for_user(db, user_id)
+    if not credential:
+        return {}
+
+    resolved_model = model or credential.current_model
+    decrypted_key = decrypt_api_key(
+        credential.encrypted_api_key,
+        credential.iv,
+        credential.auth_tag,
+    )
+
+    headers = {
+        "X-AI-Provider": credential.provider,
+        "X-AI-API-Key": decrypted_key,
+    }
+
+    if resolved_model:
+        headers["X-AI-Model"] = resolved_model
+
+    return headers

--- a/app/utils/call_ai_service.py
+++ b/app/utils/call_ai_service.py
@@ -5,12 +5,17 @@ import logging
 from fastapi import HTTPException, status
 from typing import Dict, Any, Optional
 
+from app.services.ai_credentials import resolve_ai_headers_for_user
+
 logger = logging.getLogger(__name__)
 
 
 async def call_ai_service(
     ai_service_url: str,
     payload: Dict[str, Any],
+    ai_provider: Optional[str] = None,
+    ai_model: Optional[str] = None,
+    ai_api_key: Optional[str] = None,
     retries: int = 3,
     connect_timeout: int = 10,
     read_timeout: int = 180,
@@ -34,8 +39,20 @@ async def call_ai_service(
                 f"Calling AI service (attempt {attempt}/{retries}) → {ai_service_url}"
             )
 
+            headers: Dict[str, str] = {}
+            if ai_provider:
+                headers["X-AI-Provider"] = ai_provider
+            if ai_model:
+                headers["X-AI-Model"] = ai_model
+            if ai_api_key:
+                headers["X-AI-API-Key"] = ai_api_key
+
             async with httpx.AsyncClient(timeout=timeout) as client:
-                response = await client.post(ai_service_url, json=payload)
+                response = await client.post(
+                    ai_service_url,
+                    json=payload,
+                    headers=headers or None,
+                )
 
             # try:
             #     logger.info(f"AI Response json={response.json()}")
@@ -77,10 +94,7 @@ async def call_ai_service(
 
             if "error generating document" in lowered or "error code:" in lowered:
                 logger.error(f"AI logical error (wrapped 200): {content}")
-                raise HTTPException(
-                    status_code=502,
-                    detail=content
-                )
+                raise HTTPException(status_code=502, detail=content)
 
             return data
 

--- a/app/utils/encryption.py
+++ b/app/utils/encryption.py
@@ -1,0 +1,62 @@
+import base64
+import os
+from functools import lru_cache
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from app.core.config import settings
+
+
+def _b64encode(data: bytes) -> str:
+    return base64.b64encode(data).decode("utf-8")
+
+
+def _b64decode(data: str) -> bytes:
+    return base64.b64decode(data.encode("utf-8"))
+
+
+def get_master_key() -> bytes:
+    try:
+        key = _b64decode(settings.app_aes_key)
+    except Exception as exc:
+        raise ValueError("APP_AES_KEY must be valid base64") from exc
+
+    if len(key) != 32:
+        raise ValueError("APP_AES_KEY must decode to exactly 32 bytes")
+
+    return key
+
+
+def encrypt_api_key(plain_api_key: str) -> tuple[str, str, str]:
+    if not plain_api_key or not plain_api_key.strip():
+        raise ValueError("API key must not be empty")
+
+    key = get_master_key()
+    aesgcm = AESGCM(key)
+    iv = os.urandom(12)
+
+    encrypted = aesgcm.encrypt(iv, plain_api_key.encode("utf-8"), None)
+    ciphertext = encrypted[:-16]
+    auth_tag = encrypted[-16:]
+
+    return _b64encode(ciphertext), _b64encode(iv), _b64encode(auth_tag)
+
+
+def decrypt_api_key(ciphertext_b64: str, iv_b64: str, auth_tag_b64: str) -> str:
+    key = get_master_key()
+    aesgcm = AESGCM(key)
+
+    ciphertext = _b64decode(ciphertext_b64)
+    iv = _b64decode(iv_b64)
+    auth_tag = _b64decode(auth_tag_b64)
+
+    plain = aesgcm.decrypt(iv, ciphertext + auth_tag, None)
+    return plain.decode("utf-8")
+
+
+def mask_api_key(value: str, prefix_len: int = 4) -> str:
+    if value is None:
+        return ""
+    if len(value) <= prefix_len:
+        return value
+    return value[:prefix_len] + ("*" * (len(value) - prefix_len))


### PR DESCRIPTION
This merge introduces support for per-user AI provider and API key configuration, enabling users to bring their own AI credentials (OpenAI, OpenRouter, etc.) and choose preferred models for document generation. API keys are securely encrypted and stored in the database.

What's Included
1. Database Layer - Secure Credential Storage
AICredential Model: New database table storing:
- AI provider name (openai, openrouter, anthropic, etc.)
 - Securely encrypted with AES-256 (IV + auth_tag)
 - List of available models for provider
- User's active model selection
- Credential status (active/inactive)
- Link to user account
2. Service Layer - Credential Resolution
 - Fetches user's active credential
- Decrypts API key and builds request headers:
X-AI-Provider: User's selected provider
X-AI-Model: User's selected model
X-AI-API-Key: Decrypted API key
- Falls back gracefully if no credentials configured
3. API Layer - Credential Management
- CRUD endpoints for managing credentials
- Users can add/update/delete their own AI provider credentials
- Only users can access their own credentials (user_id enforcement)
4. Utility Enhancement - Request Routing
 - Enhanced to accept optional provider/model/api_key headers