### PR TITLE
[OPS-384] fix: change call_ai_service logic to enable personal api key

### DIFF
--- a/app/api/v1/ai_credentials.py
+++ b/app/api/v1/ai_credentials.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+from app.models.ai_provider_model import AIProviderModel
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
 
@@ -15,36 +17,44 @@ from app.schemas.ai_credential import (
     SaveAICredentialResponse,
     UpdateCurrentModelRequest,
     UpdateCurrentModelResponse,
+    ClearActiveAICredentialResponse,
 )
 from app.utils.encryption import decrypt_api_key, encrypt_api_key, mask_api_key
 
 router = APIRouter()
 
 
-FIXED_PROVIDER_MODELS = {
-    "openai": [
-        "gpt-4.1",
-        "gpt-4.1-mini",
-        "gpt-4o",
-        "gpt-4o-mini",
-    ],
-    "openrouter": [
-        "openai/gpt-4o-mini",
-        "anthropic/claude-3.5-haiku",
-        "meta-llama/llama-3.1-8b-instruct",
-        "nvidia/nemotron-3-nano-30b-a3b:free",
-    ],
-    "google": [
-        "gemini-1.5-flash",
-        "gemini-1.5-pro",
-        "gemini-2.0-flash",
-    ],
-    "anthropic": [
-        "claude-haiku-4-0",
-        "claude-sonnet-4-0",
-        "claude-opus-4-0",
-    ],
-}
+## helper functions
+def _get_active_models_for_provider(
+    db: Session, provider: str
+) -> list[AIProviderModel]:
+    return (
+        db.query(AIProviderModel)
+        .filter(
+            AIProviderModel.provider == provider,
+            AIProviderModel.is_active == True,
+        )
+        .order_by(AIProviderModel.is_default.desc(), AIProviderModel.id.asc())
+        .all()
+    )
+
+
+def _get_default_model_name(models: list[AIProviderModel]) -> str | None:
+    for model in models:
+        if model.is_default:
+            return model.model_name
+    return models[0].model_name if models else None
+
+
+def _build_provider_models_response(
+    provider: str,
+    models: list[AIProviderModel],
+) -> dict:
+    return {
+        "provider": provider,
+        "models": [model.model_name for model in models],
+        "default_model": _get_default_model_name(models),
+    }
 
 
 def _build_ai_credential_response(
@@ -55,54 +65,56 @@ def _build_ai_credential_response(
         "provider": credential.provider,
         "status": credential.status,
         "current_model": credential.current_model,
-        "models_json": credential.models_json or [],
         "masked_api_key": masked_api_key,
         "updated_at": credential.updated_at,
     }
 
 
+# This endpoint returns the list of all providers with their active models. Providers without any active model will be excluded from the list.
 @router.get("/models", response_model=ProviderModelsListResponse)
-def get_all_provider_models():
+def get_all_provider_models(db: Session = Depends(get_db)):
+    rows = db.query(AIProviderModel).filter(AIProviderModel.is_active == True).all()
+
+    grouped_providers: dict[str, list[AIProviderModel]] = defaultdict(list)
+    for row in rows:
+        grouped_providers[row.provider].append(row)
+
     items = []
-    for provider, models in FIXED_PROVIDER_MODELS.items():
+    for provider, models in grouped_providers.items():
         items.append(
-            {
-                "provider": provider,
-                "models": models,
-                "default_model": models[0] if models else None,
-            }
+            _build_provider_models_response(provider, models),
         )
+
     return {"items": items}
 
 
+# This endpoint returns the list of active models for a given provider. The provider name is case-insensitive and whitespace-trimmed. If the provider does not exist or has no active models, it returns a 404 error.
 @router.get("/models/{provider}", response_model=ProviderModelsResponse)
-def get_provider_models(provider: str):
+def get_provider_models(provider: str, db: Session = Depends(get_db)):
     normalized_provider = provider.strip().lower()
-    models = FIXED_PROVIDER_MODELS.get(normalized_provider)
+    models = _get_active_models_for_provider(db, normalized_provider)
     if not models:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
-            detail="Provider not found in fixed model catalog",
+            detail="Provider not found or has no active models",
         )
 
-    return {
-        "provider": normalized_provider,
-        "models": models,
-        "default_model": models[0] if models else None,
-    }
+    return _build_provider_models_response(normalized_provider, models)
 
 
+# This endpoint saves a new API key for the user. It will automatically deactivate any existing active keys for the user to enforce single active credential. The API key is encrypted before saving, and the response includes a masked version of the key.
 @router.post("/api-key", response_model=SaveAICredentialResponse)
 def save_api_key(
     request: SaveAICredentialRequest,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
 ):
-    fixed_models = FIXED_PROVIDER_MODELS.get(request.provider)
-    if not fixed_models:
+    provider_models = _get_active_models_for_provider(db, request.provider)
+    default_model = _get_default_model_name(provider_models)
+    if not default_model:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Unsupported provider for fixed model catalog",
+            detail="Unsupported provider or provider has no active models",
         )
 
     # Enforce single active key per user by deactivating older active rows.
@@ -124,8 +136,7 @@ def save_api_key(
         encrypted_api_key=encrypted_api_key,
         iv=iv,
         auth_tag=auth_tag,
-        models_json=fixed_models,
-        current_model=fixed_models[0],
+        current_model=default_model,
         status="active",
     )
 
@@ -133,21 +144,15 @@ def save_api_key(
     db.commit()
     db.refresh(credential)
 
-    try:
-        masked = mask_api_key(
-            decrypt_api_key(
-                credential.encrypted_api_key, credential.iv, credential.auth_tag
-            )
-        )
-    except ValueError:
-        masked = ""
-
     return {
         "message": "API key saved successfully",
-        "data": _build_ai_credential_response(credential, masked),
+        "data": _build_ai_credential_response(
+            credential, mask_api_key(request.api_key)
+        ),
     }
 
 
+# This endpoint lists all API credentials for the user, including inactive ones, with masked API keys.
 @router.get("/api-keys", response_model=ListAICredentialsResponse)
 def list_api_keys(
     current_user: User = Depends(get_current_user),
@@ -177,6 +182,118 @@ def list_api_keys(
     return {"items": items}
 
 
+# This endpoint allows changing the current_model for the active credential.
+@router.patch("/api-key/current-model", response_model=UpdateCurrentModelResponse)
+def update_current_model(
+    request: UpdateCurrentModelRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    credential = (
+        db.query(AICredential)
+        .filter(
+            AICredential.user_id == current_user.id,
+            AICredential.status == "active",
+        )
+        .order_by(AICredential.updated_at.desc())
+        .first()
+    )
+
+    if not credential:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active API credential found",
+        )
+
+    allowed_model = (
+        db.query(AIProviderModel)
+        .filter(
+            AIProviderModel.provider == credential.provider,
+            AIProviderModel.is_active == True,
+            AIProviderModel.model_name == request.current_model,
+        )
+        .first()
+    )
+    if not allowed_model:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="current_model is not allowed for this provider or not active",
+        )
+
+    credential.current_model = request.current_model
+    db.commit()
+    db.refresh(credential)
+
+    try:
+        plain_api_key = decrypt_api_key(
+            credential.encrypted_api_key,
+            credential.iv,
+            credential.auth_tag,
+        )
+        masked = mask_api_key(plain_api_key)
+    except ValueError:
+        masked = ""
+
+    return {
+        "message": "Current model updated successfully",
+        "data": _build_ai_credential_response(credential, masked),
+    }
+
+
+# This endpoint returns the currently active API credential for the user.
+@router.get("/api-key", response_model=AICredentialResponse)
+def get_api_key(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    credential = (
+        db.query(AICredential)
+        .filter(
+            AICredential.user_id == current_user.id,
+            AICredential.status == "active",
+        )
+        .order_by(AICredential.updated_at.desc())
+        .first()
+    )
+
+    if not credential:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No active API key found",
+        )
+
+    try:
+        plain_api_key = decrypt_api_key(
+            credential.encrypted_api_key,
+            credential.iv,
+            credential.auth_tag,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to decrypt API key",
+        ) from exc
+
+    return _build_ai_credential_response(credential, mask_api_key(plain_api_key))
+
+
+# This endpoint allow users to deactivate all their active credentials.
+@router.patch("/api-key/clear-active", response_model=ClearActiveAICredentialResponse)
+def clear_active_api_credential(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    db.query(AICredential).filter(
+        AICredential.user_id == current_user.id,
+        AICredential.status == "active",
+    ).update({"status": "inactive"}, synchronize_session=False)
+
+    db.commit()
+
+    return {"message": "Active AI credential cleared successfully"}
+
+
+# This endpoint allows activating an existing credential by its ID. It will deactivate any other active credentials for the user.
 @router.patch(
     "/api-key/{credential_id}/activate", response_model=ActivateAICredentialResponse
 )
@@ -222,91 +339,4 @@ def activate_api_credential(
     return {
         "message": "AI credential activated successfully",
         "data": _build_ai_credential_response(credential, masked),
-    }
-
-
-@router.patch("/api-key/current-model", response_model=UpdateCurrentModelResponse)
-def update_current_model(
-    request: UpdateCurrentModelRequest,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    credential = (
-        db.query(AICredential)
-        .filter(
-            AICredential.user_id == current_user.id,
-            AICredential.status == "active",
-        )
-        .order_by(AICredential.updated_at.desc())
-        .first()
-    )
-
-    if not credential:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No active API credential found",
-        )
-
-    allowed_models = credential.models_json or []
-    if request.current_model not in allowed_models:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="current_model is not allowed for the active credential",
-        )
-
-    credential.current_model = request.current_model
-    db.commit()
-    db.refresh(credential)
-
-    try:
-        plain_api_key = decrypt_api_key(
-            credential.encrypted_api_key,
-            credential.iv,
-            credential.auth_tag,
-        )
-        masked = mask_api_key(plain_api_key)
-    except ValueError:
-        masked = ""
-
-    return {
-        "message": "Current model updated successfully",
-        "data": _build_ai_credential_response(credential, masked),
-    }
-
-
-@router.get("/api-key", response_model=AICredentialResponse)
-def get_api_key(
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-):
-    credential = (
-        db.query(AICredential)
-        .filter(
-            AICredential.user_id == current_user.id,
-            AICredential.status == "active",
-        )
-        .order_by(AICredential.updated_at.desc())
-        .first()
-    )
-
-    if not credential:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No active API key found",
-        )
-
-    try:
-        plain_api_key = decrypt_api_key(
-            credential.encrypted_api_key,
-            credential.iv,
-            credential.auth_tag,
-        )
-    except ValueError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to decrypt API key",
-        ) from exc
-
-    return {
-        **_build_ai_credential_response(credential, mask_api_key(plain_api_key)),
     }

--- a/app/api/v1/analysis.py
+++ b/app/api/v1/analysis.py
@@ -96,7 +96,12 @@ async def generate_analysis_doc(
     file_urls = await list_file(project_id, db, current_user)
     ai_payload = {"message": description, "storage_paths": file_urls}
 
-    ai_data = await call_ai_service(get_ai_endpoint(doc_type), ai_payload)
+    ai_data = await call_ai_service(
+        get_ai_endpoint(doc_type),
+        ai_payload,
+        db=db,
+        user_id=current_user.id,
+    )
     ai_inner = ai_data.get("response", {})
     content = format_response(ai_inner)
 
@@ -339,6 +344,8 @@ async def regenerate_analysis_doc(
     ai_data = await call_ai_service(
         get_ai_endpoint(doc.file_type),
         ai_payload,
+        db=db,
+        user_id=current_user.id,
     )
     ai_inner = ai_data.get("response", {})
     content = format_response(ai_inner)

--- a/app/api/v1/design.py
+++ b/app/api/v1/design.py
@@ -133,7 +133,12 @@ async def generate_design(
 
     generate_at = datetime.now(timezone.utc)
 
-    ai_data = await call_ai_service(ai_url, ai_payload)
+    ai_data = await call_ai_service(
+        ai_url,
+        ai_payload,
+        db=db,
+        user_id=current_user.id,
+    )
     ai_inner_response = ai_data.get("response", {})
     ai_inner_content = ai_inner_response.get("content", {})
     html_content, css_content = extract_html_css_from_content(
@@ -406,7 +411,12 @@ async def regenerate_design(
         "storage_paths": file_urls,
     }
 
-    ai_data = await call_ai_service(ai_url, ai_payload)
+    ai_data = await call_ai_service(
+        ai_url,
+        ai_payload,
+        db=db,
+        user_id=current_user.id,
+    )
     ai_inner_response = ai_data.get("response", {})
     markdown_content = format_design_response(ai_inner_response)
 

--- a/app/api/v1/planning.py
+++ b/app/api/v1/planning.py
@@ -100,7 +100,12 @@ async def generate_planning_doc(
     file_urls = await list_file(project_id, db, current_user)
     ai_payload = {"message": description, "storage_paths": file_urls}
 
-    ai_data = await call_ai_service(ai_url, ai_payload)
+    ai_data = await call_ai_service(
+        ai_url,
+        ai_payload,
+        db=db,
+        user_id=current_user.id,
+    )
 
     # Xử lý response từ AI (giả sử AI trả về {"response": {...}})
     ai_inner_resp = ai_data.get("response", {})
@@ -343,7 +348,12 @@ async def regenerate_planning_doc(
         "storage_paths": file_urls,
     }
 
-    ai_data = await call_ai_service(get_ai_endpoint(doc.file_type), ai_payload)
+    ai_data = await call_ai_service(
+        get_ai_endpoint(doc.file_type),
+        ai_payload,
+        db=db,
+        user_id=current_user.id,
+    )
     ai_inner = ai_data.get("response", {})
     content = format_response(ai_inner)
 

--- a/app/models/ai_credential.py
+++ b/app/models/ai_credential.py
@@ -5,11 +5,7 @@ from sqlalchemy import (
     DateTime,
     ForeignKey,
     Text,
-    JSON,
-    Index,
-    text,
 )
-from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -25,9 +21,6 @@ class AICredential(Base):
     encrypted_api_key = Column(Text, nullable=False)
     iv = Column(String(255), nullable=False)
     auth_tag = Column(String(255), nullable=False)
-    models_json = Column(
-        JSONB().with_variant(JSON(), "sqlite"), nullable=False, default=list
-    )
     current_model = Column(String(100), nullable=True)
     status = Column(String(20), nullable=False, default="active")
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/app/models/ai_provider_model.py
+++ b/app/models/ai_provider_model.py
@@ -1,0 +1,26 @@
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, UniqueConstraint
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class AIProviderModel(Base):
+    __tablename__ = "ai_provider_models"
+
+    id = Column(Integer, primary_key=True, index=True)
+    provider = Column(String(50), nullable=False, index=True)
+    model_name = Column(String(150), nullable=False)
+    is_default = Column(Boolean, nullable=False, default=False)
+    is_active = Column(Boolean, nullable=False, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "provider",
+            "model_name",
+            name="ai_provider_models_unique_provider_model",
+        ),
+    )

--- a/app/schemas/ai_credential.py
+++ b/app/schemas/ai_credential.py
@@ -44,7 +44,6 @@ class AICredentialResponse(BaseResponseModel):
     provider: str
     status: str
     current_model: Optional[str] = None
-    models_json: List[str] = Field(default_factory=list)
     masked_api_key: str
     updated_at: datetime
 
@@ -79,3 +78,6 @@ class ProviderModelsResponse(BaseResponseModel):
 
 class ProviderModelsListResponse(BaseResponseModel):
     items: List[ProviderModelsResponse] = Field(default_factory=list)
+
+class ClearActiveAICredentialResponse(BaseResponseModel):
+    message: str

--- a/app/tasks/file_tasks.py
+++ b/app/tasks/file_tasks.py
@@ -142,6 +142,8 @@ def extract_metadata_task(self, payload: dict):
             call_ai_service(
                 ai_service_url=settings.ai_service_url_metadata_extraction,
                 payload=metadata_payload,
+                db=db,
+                user_id=file_record.created_by,
             )
         )
 

--- a/app/utils/call_ai_service.py
+++ b/app/utils/call_ai_service.py
@@ -4,7 +4,7 @@ import httpx
 import logging
 from fastapi import HTTPException, status
 from typing import Dict, Any, Optional
-
+from sqlalchemy.orm import Session
 from app.services.ai_credentials import resolve_ai_headers_for_user
 
 logger = logging.getLogger(__name__)
@@ -13,12 +13,32 @@ GENERIC_AI_ERROR = (
     "Something went wrong while processing your request. Please try again later."
 )
 
+
+# helper function to detect quota errors in AI responses
+def _is_quota_or_token_error(data: Any) -> bool:
+    text = str(data or "").lower()
+    keywords = (
+        "quota",
+        "insufficient_quota",
+        "resource_exhausted",
+        "rate limit",
+        "rate_limit",
+        "too many requests",
+        "token limit",
+        "tokens",
+        "billing",
+        "credit",
+        "credits",
+        "exceeded",
+    )
+    return any(keyword in text for keyword in keywords)
+
+
 async def call_ai_service(
     ai_service_url: str,
     payload: Dict[str, Any],
-    ai_provider: Optional[str] = None,
-    ai_model: Optional[str] = None,
-    ai_api_key: Optional[str] = None,
+    db: Optional[Session] = None,
+    user_id: Optional[int] = None,
     retries: int = 3,
     connect_timeout: int = 10,
     read_timeout: int = 180,
@@ -32,6 +52,12 @@ async def call_ai_service(
         pool=10,
     )
 
+    headers: Dict[str, str] = {}
+    if db and user_id:
+        ai_headers = resolve_ai_headers_for_user(db, user_id)
+        if ai_headers:
+            headers.update(ai_headers)
+
     for attempt in range(1, retries + 1):
         if asyncio.current_task() and asyncio.current_task().cancelled():
             logger.info(f"Task cancelled before attempt {attempt}")
@@ -41,14 +67,6 @@ async def call_ai_service(
             logger.info(
                 f"Calling AI service (attempt {attempt}/{retries}) → {ai_service_url}"
             )
-
-            headers: Dict[str, str] = {}
-            if ai_provider:
-                headers["X-AI-Provider"] = ai_provider
-            if ai_model:
-                headers["X-AI-Model"] = ai_model
-            if ai_api_key:
-                headers["X-AI-API-Key"] = ai_api_key
 
             async with httpx.AsyncClient(timeout=timeout) as client:
                 response = await client.post(
@@ -75,6 +93,11 @@ async def call_ai_service(
             if response.status_code >= 400:
                 last_error = f"AI error: {data}"
                 logger.warning(last_error)
+                if _is_quota_or_token_error(data):
+                    raise HTTPException(
+                        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                        detail="AI service error: quota exceeded or token limit reached",
+                    )
 
                 if attempt == retries:
                     raise HTTPException(
@@ -82,10 +105,10 @@ async def call_ai_service(
                         detail=GENERIC_AI_ERROR,
                     )
                 continue
-            
+
             if data.get("type") == "metadata_extraction":
-                return data 
-            
+                return data
+
             ai_res = data.get("response")
 
             content = ai_res.get("content")
@@ -93,6 +116,14 @@ async def call_ai_service(
 
             if inner_status != 200:
                 logger.error(f"AI logical error: {content}")
+                if _is_quota_or_token_error(content):
+                    logger.warning(
+                        f"AI quota/token error detected in content: {content}"
+                    )
+                    raise HTTPException(
+                        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                        detail="AI service error: quota exceeded or token limit reached",
+                    )
                 raise HTTPException(
                     status_code=502,
                     detail=GENERIC_AI_ERROR,


### PR DESCRIPTION
## Commit Description

### Summary
Enable user-specific AI credentials by updating `call_ai_service` to resolve provider, model, and API key from the backend database instead of receiving them directly as parameters.

### Changes
- Added `AIProviderModel` to store provider/model catalog in the database.
- Removed hard-coded provider model lists from `ai_credentials` API logic.
- Updated AI credential endpoints to read active provider models from `ai_provider_models`.
- Removed `models_json` from `AICredential` and related response schemas.
- Added support for clearing the active AI credential so users can fall back to the AI service default key.
- Updated `call_ai_service` to:
  - accept `db` and `user_id`;
  - resolve active user credentials automatically;
  - attach AI provider/model/API key headers when available;
  - detect quota/token-related AI errors.
- Updated Analysis, Planning, Design, and metadata extraction call sites to pass `db` and user id into `call_ai_service`.

### Notes
- If no active user credential exists, the AI service is called without custom AI headers and can use its own environment-configured API key.
- `srs.py`, `wireframe.py`, and `diagram.py` call sites remain unchanged in this commit.