### PR TITLE
Refactor session listing logic and add a dedicated endpoint for AI services.

### DIFF
--- a/app/api/v1/session.py
+++ b/app/api/v1/session.py
@@ -1,10 +1,6 @@
 import json
 import logging
-from uuid import UUID
-from fastapi import (
-    APIRouter,
-    Depends,
-)
+from fastapi import APIRouter, Depends
 from sqlalchemy.orm import Session
 
 from app.core.database import get_db
@@ -13,26 +9,18 @@ from app.schemas.session import (
     ListSessionResponse,
     GetSessionResponse,
 )
-from app.utils.file_handling import extract_html_css_from_content, merge_html_css
+from app.utils.file_handling import (
+    extract_html_css_from_content,
+    merge_html_css,
+)
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.get("/list/{content_id}", response_model=ListSessionResponse)
-async def list_Session(
-    content_id: str,
-    db: Session = Depends(get_db),
-):
-
-    session_list = (
-        db.query(Chat_Session)
-        .filter(Chat_Session.content_id == content_id)
-        .order_by(Chat_Session.created_at.asc())
-        .all()
-    )
-
+def build_session_response(session_list):
     result = []
+
     for session in session_list:
         message = ""
         summary = ""
@@ -45,13 +33,14 @@ async def list_Session(
                 if isinstance(content, dict):
                     html_content, css_content = extract_html_css_from_content(content)
                     message = merge_html_css(html_content, css_content or "")
-
                 elif isinstance(content, str):
                     message = content
                 else:
                     message = ""
+
                 summary = parsed.get("summary") or ""
-            except:
+
+            except Exception:
                 message = session.message or ""
         else:
             message = session.message or ""
@@ -64,4 +53,36 @@ async def list_Session(
                 create_at=session.created_at,
             )
         )
-    return {"Sessions": result}
+
+    return result
+
+
+@router.get("/list/{content_id}", response_model=ListSessionResponse)
+async def list_session(
+    content_id: str,
+    db: Session = Depends(get_db),
+):
+    session_list = (
+        db.query(Chat_Session)
+        .filter(Chat_Session.content_id == content_id)
+        .order_by(Chat_Session.created_at.asc())
+        .all()
+    )
+
+    return {"Sessions": build_session_response(session_list)}
+
+
+@router.get("/list-ai/{content_id}", response_model=ListSessionResponse)
+async def list_session_ai(
+    content_id: str,
+    db: Session = Depends(get_db),
+):
+    session_list = (
+        db.query(Chat_Session)
+        .filter(Chat_Session.content_id == content_id)
+        .order_by(Chat_Session.created_at.desc())
+        .limit(3)
+        .all()
+    )
+
+    return {"Sessions": build_session_response(session_list)}


### PR DESCRIPTION
## Changes

* Extracted shared session response mapping into `build_session_response()` to eliminate duplicated logic.
* Improved exception handling by replacing bare `except` with `except Exception`.
* Added a new endpoint:

  * `GET /list-ai/{content_id}`
  * Returns the **3 most recent sessions** (ordered by `created_at DESC`) for AI services.
* Kept the existing endpoint:

  * `GET /list/{content_id}`
  * Returns the **full session history** (ordered by `created_at ASC`) for frontend usage.
* Cleaned up duplicate imports and improved code readability.

## API Behavior

### Frontend

* **GET** `/list/{content_id}`
* Returns all sessions in chronological order.

### AI Service

* **GET** `/list-ai/{content_id}`
* Returns the latest 3 sessions for AI context.

## Benefits

* Reduces duplicated code.
* Separates frontend and AI use cases.
* Improves maintainability and readability.
* Minimizes the amount of context sent to AI while preserving existing frontend behavior.
