### PR TITLE
fix: only query ai generation document in list_documents service method

### DIFF
--- a/app/services/document_generation.py
+++ b/app/services/document_generation.py
@@ -282,6 +282,7 @@ def list_documents(
 ):
     query = db.query(Files).filter(
         Files.project_id == project_id,
+        Files.file_category == "ai gen",
     )
     if document_type:
         query = query.filter(Files.file_type == document_type)


### PR DESCRIPTION
## Summary

Update the document listing query to return only AI-generated documents.

### Changes

* Added `Files.file_category == "ai gen"` to the base query in `list_documents()`.
* Kept the existing `file_type` filtering logic unchanged.

### Reason

Previously, the endpoint could return all documents under a project, including manually created files. This change ensures that only documents generated by the AI generation workflow are included in the response, making the API behavior consistent with its intended purpose.
